### PR TITLE
Typo - 12PM to 12AM

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -112,7 +112,7 @@ export default function Home() {
             the total USA population, E kala mai iaʻu Alaska and Hawaii :(
           </li>
           <li>
-            I consider awake to mean from 8AM to 12PM, you <em>are</em> getting
+            I consider awake to mean from 8AM to 12AM, you <em>are</em> getting
             at least 8 hours of sleep, right?
           </li>
           <li>


### PR DESCRIPTION
Saw the website from hackernews. 8AM - 12PM would mean 20 hours of sleep as 12PM is noon  :).